### PR TITLE
Add wiki filter on "type" meta field

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -3,6 +3,7 @@ import logging
 from datasets import Dataset, load_dataset, load_from_disk
 
 from datasets.utils.logging import set_verbosity_info
+from clean_helpers import filter_wiki_non_text_type
 
 set_verbosity_info()
 logger = logging.getLogger(__name__)
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 # Map functions
 MAPS = {}
 # Filter functions
-FILTERS = {}
+FILTERS = {
+    "filter_wiki_non_text_type": filter_wiki_non_text_type
+}
 
 assert set(MAPS.keys()).isdisjoint(set(FILTERS.keys()))
 

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -1,0 +1,1 @@
+from .filter_wiki_meta import filter_wiki_non_text_type

--- a/clean_helpers/filter_wiki_meta.py
+++ b/clean_helpers/filter_wiki_meta.py
@@ -1,0 +1,2 @@
+def filter_wiki_non_text_type(examples):
+    return [True if eval(meta)["type"] == "text" else False for meta in examples["meta"]]

--- a/clean_helpers/filter_wiki_meta.py
+++ b/clean_helpers/filter_wiki_meta.py
@@ -1,2 +1,2 @@
 def filter_wiki_non_text_type(examples):
-    return [True if eval(meta)["type"] == "text" else False for meta in examples["meta"]]
+    return [eval(meta)["type"] == "text" for meta in examples["meta"]]


### PR DESCRIPTION
This PR add a filter that filters out all the examples that doesn't have their "type" field inside their "meta" value equal to "text".

I've tested it on `lm_en_wikinews_filtered`, here's the logs:
```bash
03/03/2022 11:46:20 - INFO - __main__ - Applied filter: filter_wiki_non_text_type
03/03/2022 11:46:20 - INFO - __main__ -      Initial number of samples: 54387 samples
03/03/2022 11:46:20 - INFO - __main__ -      Removed samples: 24736 samples
03/03/2022 11:46:20 - INFO - __main__ -      Removed percentage: 45.48 %
```

Partially solves #5 