### PR TITLE
Add User filter on wiki page

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -3,7 +3,7 @@ import logging
 from datasets import Dataset, load_dataset, load_from_disk
 
 from datasets.utils.logging import set_verbosity_info
-from clean_helpers import filter_user_titles, filter_wiki_non_text_type
+from clean_helpers import filter_wiki_user_titles, filter_wiki_non_text_type
 
 set_verbosity_info()
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 MAPS = {}
 # Filter functions
 FILTERS = {
-    "filter_user_titles": filter_user_titles,
+    "filter_wiki_user_titles": filter_wiki_user_titles,
     "filter_wiki_non_text_type": filter_wiki_non_text_type,
 }
 
@@ -38,7 +38,7 @@ def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: i
         return mapped_function
     elif function_name in FILTERS:
         filter_function = FILTERS[function_name]
-        filtered_ds = ds.filter(filter_function, batched=True, num_proc=num_proc, batch_size=batch_size)
+        filtered_ds = ds.filter(filter_function, batched=True, num_proc=num_proc, batch_size=batch_size, load_from_cache_file=False)
         logger.info(f"Applied filter: {function_name}")
         logger.info(f"     Initial number of samples: {len(ds)} samples")
         logger.info(f"     Removed samples: {len(ds) - len(filtered_ds)} samples")

--- a/clean.py
+++ b/clean.py
@@ -3,6 +3,7 @@ import logging
 from datasets import Dataset, load_dataset, load_from_disk
 
 from datasets.utils.logging import set_verbosity_info
+from clean_helpers import filter_user_titles
 
 set_verbosity_info()
 logger = logging.getLogger(__name__)
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 # Map functions
 MAPS = {}
 # Filter functions
-FILTERS = {}
+FILTERS = {
+    "filter_user_titles": filter_user_titles
+}
 
 assert set(MAPS.keys()).isdisjoint(set(FILTERS.keys()))
 

--- a/clean.py
+++ b/clean.py
@@ -38,7 +38,7 @@ def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: i
         return mapped_function
     elif function_name in FILTERS:
         filter_function = FILTERS[function_name]
-        filtered_ds = ds.filter(filter_function, batched=True, num_proc=num_proc, batch_size=batch_size, load_from_cache_file=False)
+        filtered_ds = ds.filter(filter_function, batched=True, num_proc=num_proc, batch_size=batch_size)
         logger.info(f"Applied filter: {function_name}")
         logger.info(f"     Initial number of samples: {len(ds)} samples")
         logger.info(f"     Removed samples: {len(ds) - len(filtered_ds)} samples")

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -1,1 +1,1 @@
-from .filter_wiki_meta import filter_user_titles, filter_wiki_non_text_type
+from .filter_wiki_meta import filter_wiki_user_titles, filter_wiki_non_text_type

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -1,0 +1,1 @@
+from .filter_wiki_meta import filter_user_titles

--- a/clean_helpers/filter_wiki_meta.py
+++ b/clean_helpers/filter_wiki_meta.py
@@ -1,0 +1,2 @@
+def filter_user_titles(examples):
+    return [not eval(meta)["title"].startswith("User ") for meta in examples["meta"]]

--- a/clean_helpers/filter_wiki_meta.py
+++ b/clean_helpers/filter_wiki_meta.py
@@ -1,4 +1,4 @@
-def filter_user_titles(examples):
+def filter_wiki_user_titles(examples):
     return [not eval(meta)["title"].startswith("User ") for meta in examples["meta"]]
 
 def filter_wiki_non_text_type(examples):

--- a/slurm/cleaning_filtering/00_test_filter_user_titles.sh
+++ b/slurm/cleaning_filtering/00_test_filter_user_titles.sh
@@ -1,0 +1,12 @@
+conda activate datacatalog
+
+CATALOGUE_DATA_REPO="/home/lucile/code/catalogue_data"
+
+cd $CATALOGUE_DATA_REPO
+
+python clean.py \
+    --dataset-path bigscience-catalogue-lm-data/lm_en_wikinews_filtered \
+    --maps-and-filters filter_wiki_user_titles \
+    --save-path /home/lucile/data/result_filtering_cleaning/lm_en_wikinews_filtered.jsonl \
+    --num-proc 4 \
+    --batch-size 100


### PR DESCRIPTION
This PR add a filter that filters out all the examples whose "title" field insed their "meta" value starts with "User ". The goal here is to remove these type of examples:
```
"Users in this category indicate they have knowledge of language Nepali."
```
```
"Users in this category indicate they have skill level 1 for language Low Saxon."
```



I've tested it on lm_en_wikinews_filtered, here's the logs:

```
03/03/2022 12:33:09 - INFO - __main__ - Applied filter: filter_user_titles
03/03/2022 12:33:09 - INFO - __main__ -      Initial number of samples: 54387 samples
03/03/2022 12:33:09 - INFO - __main__ -      Removed samples: 345 samples
03/03/2022 12:33:09 - INFO - __main__ -      Removed percentage: 0.63 %
```

I've also checked by hand all the filtered out examples and all of them corresponds to examples that we want to filter out.

Partially solves https://github.com/bigscience-workshop/catalogue_data/issues/5

Remaining todo: have the list of datasets we want this filter apply on