### PR TITLE
Replace \n with empty space

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -3,15 +3,16 @@ import logging
 from datasets import Dataset, load_dataset, load_from_disk
 
 from datasets.utils.logging import set_verbosity_info
-from clean_helpers import filter_wiki_user_titles, filter_wiki_non_text_type
-from clean_helpers import build_small_docs_filter
+from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, filter_wiki_user_titles, replace_newline_with_space
 
 set_verbosity_info()
 logger = logging.getLogger(__name__)
 
 
 # Map functions
-MAPS = {}
+MAPS = {
+    "replace_newline_with_space": replace_newline_with_space
+}
 # Filter functions
 FILTERS = {
     "filter_wiki_user_titles": filter_wiki_user_titles,

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -1,2 +1,3 @@
 from .filter_wiki_meta import filter_wiki_user_titles, filter_wiki_non_text_type
 from .filter_small_docs_in_datasets import build_small_docs_filter
+from .map_arabic import replace_newline_with_space

--- a/clean_helpers/map_arabic.py
+++ b/clean_helpers/map_arabic.py
@@ -1,0 +1,5 @@
+def replace_newline_with_space(batch):
+    return {
+        **batch,
+        "text": [text.replace("\n", " ") for text in batch["text"]]
+    }


### PR DESCRIPTION
Looking at the sheet, `bigscience-catalogue-lm-data/lm_ar_kalimat` suffers from having replaced all empty space with "\n"

This fixes it. Meaning that `\n` doesn't exist anymore. If there is templating, line duplication won't catch it.

cc @cakiki