### PR TITLE
Add feature to see the modified examples by a map operation

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -70,7 +70,7 @@ def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: i
             )
             logger.info(f"     Initial number of samples: {len(ds)} samples")
             logger.info(f"     Modified samples: {len(ds) - len(mapped_diff_ds)} samples")
-            logger.info(f"     Modified percentage: {(len(ds) - len(mapped_diff_ds)) / len(ds) * 100:.2f} %")
+            logger.info(f"     Modified percentage: {(len(ds) - len(mapped_diff_ds)) / len(ds):.2%}")
             idx_samples = random.sample(range(len(mapped_diff_ds)), min(len(mapped_diff_ds), 10))
             logger.info("Examples of modified examples:")
             for idx in idx_samples:

--- a/clean.py
+++ b/clean.py
@@ -54,6 +54,7 @@ def get_args():
     return args
 
 def log_stats(title: str, original_size: int, after_transformation_size: int, operation_type: str):
+    logger.info(title)
     logger.info(f"     Initial number of samples: {original_size} samples")
     logger.info(f"     {operation_type} samples: {original_size - after_transformation_size} samples")
     logger.info(f"     {operation_type} percentage: {(original_size - after_transformation_size) / original_size * 100:.2f} %")

--- a/clean.py
+++ b/clean.py
@@ -1,6 +1,9 @@
+import os
 import argparse
 import logging
+import random
 from datasets import Dataset, load_dataset, load_from_disk
+from functools import partial
 
 from datasets.utils.logging import set_verbosity_info
 from clean_helpers import filter_wiki_non_text_type
@@ -18,23 +21,28 @@ FILTERS = {
 
 assert set(MAPS.keys()).isdisjoint(set(FILTERS.keys()))
 
+def revert_bool_output(examples, filter_function):
+    booleans = filter_function(examples)
+    return [not boolean for boolean in booleans]
+    
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset-path", type=str, required=True)
     parser.add_argument("--maps-and-filters", nargs="+", type=str, required=True)
     parser.add_argument("--save-path", type=str, required=True)
+    parser.add_argument("--checks-save-path", type=str, default=None)
     parser.add_argument("--num-proc", type=int, default=1)
     parser.add_argument("--batch-size", type=int)
     parser.add_argument("--load-arrow-file", action="store_true")
     args = parser.parse_args()
     return args
 
-def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: int) -> Dataset:
+def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: int, save_checks: bool) -> Dataset:
     if function_name in MAPS:
         map_function = MAPS[function_name]
         mapped_function = ds.map(map_function, batched=True, num_proc=num_proc, batch_size=batch_size)
         logger.info(f"Applied map function: {function_name}")
-        return mapped_function
+        return mapped_function, None
     elif function_name in FILTERS:
         filter_function = FILTERS[function_name]
         filtered_ds = ds.filter(filter_function, batched=True, num_proc=num_proc, batch_size=batch_size)
@@ -42,7 +50,19 @@ def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: i
         logger.info(f"     Initial number of samples: {len(ds)} samples")
         logger.info(f"     Removed samples: {len(ds) - len(filtered_ds)} samples")
         logger.info(f"     Removed percentage: {(len(ds) - len(filtered_ds)) / len(ds) * 100:.2f} %")
-        return filtered_ds
+        if save_checks:
+            filtered_out_ds = ds.filter(
+                    partial(revert_bool_output, filter_function=filter_function), 
+                    batched=True, num_proc=num_proc, 
+                    batch_size=batch_size
+                )
+            idx_samples = random.sample(range(len(filtered_out_ds)), min(len(filtered_out_ds), 10))
+            logger.info("Examples of filtered out examples:")
+            for idx in idx_samples:
+                logger.info(f"     Examples n°{idx} of filtered out examples:\n{filtered_out_ds[idx]}")
+            return filtered_ds, filtered_out_ds
+        else:
+            return filtered_ds, None
     else:
         raise NotImplemented(f"{function_name} has not matched any existing function names. Available names:\n"
                              f"Map functions: {MAPS.keys()}\n"
@@ -67,7 +87,12 @@ def main():
     # Apply series of maps and filters
     logger.info(f" ===== Applying transformations =====")
     for map_or_filter in args.maps_and_filters:
-        ds = apply_function(map_or_filter, ds, args.num_proc, args.batch_size)
+        ds, ds_out = apply_function(map_or_filter, ds, args.num_proc, args.batch_size, save_checks= args.checks_save_path is not None)
+        if ds_out is not None and len(ds_out) != 0:
+            saving_path = os.path.join(args.checks_save_path, f"{map_or_filter}_checks")
+            logger.info(f" ===== Saving examples to check after {map_or_filter}  =====")
+            ds_out.save_to_disk(saving_path)
+
 
     # Save to disk
     logger.info(f" ===== Saving dataset =====")

--- a/clean.py
+++ b/clean.py
@@ -1,7 +1,7 @@
-import os
 import argparse
 import logging
 import random
+from functools import partial
 from datasets import Dataset, load_dataset, load_from_disk, concatenate_datasets
 from pathlib import Path
 from typing import Tuple, Optional

--- a/clean.py
+++ b/clean.py
@@ -69,9 +69,9 @@ def apply_function(function_name: str, ds: Dataset, num_proc: int, batch_size: i
             logger.info(f"     Modified samples: {len(ds) - len(mapped_diff_ds)} samples")
             logger.info(f"     Modified percentage: {(len(ds) - len(mapped_diff_ds)) / len(ds) * 100:.2f} %")
             idx_samples = random.sample(range(len(mapped_diff_ds)), min(len(mapped_diff_ds), 10))
-            logger.info("Examples of filtered out examples:")
+            logger.info("Examples of modified examples:")
             for idx in idx_samples:
-                logger.info(f"     Examples n°{idx} of filtered out examples:\n{mapped_diff_ds[idx]}")
+                logger.info(f"     Examples n°{idx} :\n{mapped_diff_ds[idx]}")
             mapped_ds = mapped_ds.remove_columns([in_text_col_map])
             mapped_ds = mapped_ds.rename_column(out_text_col_map, in_text_col_map)
             return mapped_ds, mapped_diff_ds
@@ -116,7 +116,7 @@ def main():
     if args.load_arrow_file:
         ds = load_from_disk(args.dataset_path)
     else:
-        ds = load_dataset(args.dataset_path, split="train", ignore_verifications=True)
+        ds = load_dataset(args.dataset_path, split="train", use_auth_token=True, ignore_verifications=True)
 
     # Apply series of maps and filters
     logger.info(f" ===== Applying transformations =====")

--- a/clean.py
+++ b/clean.py
@@ -171,7 +171,7 @@ def main():
             saving_path = args.checks_save_path / f"{idx}_{map_or_filter}_checks"
             if saving_path.exists():
                 continue
-            tmp_save_path = Path(saving_path.parent, f"{saving_path.name}.tmp")
+            tmp_save_path = Path(saving_path.parent, f"tmp-{saving_path.name}")
             logger.info(f" ===== Saving examples to check after {map_or_filter}  =====")
             ds_out.save_to_disk(tmp_save_path)
             tmp_save_path.rename(saving_path)
@@ -181,7 +181,7 @@ def main():
     if not args.save_path.exists():
         logger.info(f" ===== Saving dataset =====")
         logger.info(f"Saving to json format at {args.save_path}.")
-        tmp_save_path = Path(args.save_path.parent, f"{args.save_path.name}.tmp")
+        tmp_save_path = Path(args.save_path.parent, f"tmp-{args.save_path.name}")
         ds.to_json(
             tmp_save_path,
             num_proc=args.num_proc

--- a/clean_helpers/map_arabic.py
+++ b/clean_helpers/map_arabic.py
@@ -1,5 +1,5 @@
-def replace_newline_with_space(batch, in_text_col, out_text_col):
+def replace_newline_with_space(batch):
     return {
         **batch,
-        out_text_col: [text.replace("\n", " ") for text in batch[in_text_col]]
+        "text": [text.replace("\n", " ") for text in batch["text"]]
     }

--- a/clean_helpers/map_arabic.py
+++ b/clean_helpers/map_arabic.py
@@ -1,5 +1,5 @@
-def replace_newline_with_space(batch):
+def replace_newline_with_space(batch, in_text_col, out_text_col):
     return {
         **batch,
-        "text": [text.replace("\n", " ") for text in batch["text"]]
+        out_text_col: [text.replace("\n", " ") for text in batch[in_text_col]]
     }


### PR DESCRIPTION
This PR proposes a feature to view and save examples which are different after a map operation.

~If we think that the created dataset `mapped_diff_ds` might be to big, we can implement in a next PR something to only save a subset of it.~

~I've modified `replace_newline_with_space` to match the new requirement of in and out text columns~

~Please note: the git diff in shown to this PR #15~