### PR TITLE
Curly fix

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -6,7 +6,7 @@ from datasets import Dataset, load_dataset, load_from_disk, concatenate_datasets
 from pathlib import Path
 from typing import Tuple, Optional, Callable
 from datasets.utils.logging import set_verbosity_info
-from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, filter_wiki_user_titles, replace_newline_with_space
+from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, filter_wiki_user_titles, replace_newline_with_space, remove_lines_with_curly_brackets
 
 set_verbosity_info()
 logger = logging.getLogger(__name__)
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 # Map functions: function(batch: Dict) -> Dict
 MAPS = {
-    "replace_newline_with_space": replace_newline_with_space
+    "replace_newline_with_space": replace_newline_with_space,
+    "remove_lines_with_curly_brackets": remove_lines_with_curly_brackets
 }
 # Filter functions: function(batch: Dict) -> Dict
 FILTERS = {

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -1,3 +1,4 @@
 from .filter_wiki_meta import filter_wiki_user_titles, filter_wiki_non_text_type
 from .filter_small_docs_in_datasets import build_small_docs_filter
 from .map_arabic import replace_newline_with_space
+from .clean_pseudocrawl import remove_lines_with_curly_brackets

--- a/clean_helpers/clean_pseudocrawl.py
+++ b/clean_helpers/clean_pseudocrawl.py
@@ -1,4 +1,5 @@
 def remove_lines_with_curly_brackets(examples):
+    """Removes lines containing a '{' from the texts."""
     fixed_texts = []
     for text in examples["text"]:
         fixed_lines = []

--- a/clean_helpers/clean_pseudocrawl.py
+++ b/clean_helpers/clean_pseudocrawl.py
@@ -1,0 +1,10 @@
+def remove_lines_with_curly_brackets(examples):
+    fixed_texts = []
+    for text in examples["text"]:
+        fixed_lines = []
+        for line in text.split("\n"):
+            if "{" not in line:
+                fixed_lines.append(line)
+        fixed_texts.append("\n".join(fixed_lines))
+    examples["text"] = fixed_texts
+    return examples


### PR DESCRIPTION
This PR adds a function to remove lines containing a curly bracket (found in `es` pseudocrawl data). 