### PR TITLE
remove whitespace, numbers and punctuation before hashing

### DIFF
--- a/clean_helpers/deduplication.py
+++ b/clean_helpers/deduplication.py
@@ -53,7 +53,7 @@ def build_dedup_template(min_template_line_size: int, min_template_line_occurenc
 
 def dedup_document(ds: Dataset, num_proc: int, batch_size: int) -> Dataset:
     hashed_documents = ds.map(
-        lambda batch: {**batch, "hash": get_hash(batch["text"])},
+        lambda batch: {**batch, "hash": get_hash_stripped(batch["text"])},
         num_proc=num_proc,
         batched=True,
         batch_size=batch_size,

--- a/clean_helpers/deduplication.py
+++ b/clean_helpers/deduplication.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import List, Set, Tuple
 import hashlib
+import re
+import string
 
 from datasets import Dataset
 
@@ -72,7 +74,8 @@ def dedup_document(ds: Dataset, num_proc: int, batch_size: int) -> Dataset:
 
 def get_hash(texts: List[str]) -> List[str]:
     """Get hash of content field."""
-    return [hashlib.md5(text.strip().encode("utf-8")).hexdigest() for text in texts]
+    stripped_texts = [re.sub(f'\s+|\d+|[{re.escape(string.punctuation)}]','', text) for text in texts]
+    return [hashlib.md5(text.strip().encode("utf-8")).hexdigest() for text in stripped_texts]
 
 
 def split_text_in_lines(text: str) -> List[str]:

--- a/clean_helpers/deduplication.py
+++ b/clean_helpers/deduplication.py
@@ -72,10 +72,16 @@ def dedup_document(ds: Dataset, num_proc: int, batch_size: int) -> Dataset:
 
 # =========== HELPERS ===============
 
-def get_hash(texts: List[str]) -> List[str]:
+# this only keeps letter characters
+def get_hash_stripped(texts: List[str]) -> List[str]:
     """Get hash of content field."""
     stripped_texts = [re.sub(f'\s+|\d+|[{re.escape(string.punctuation)}]','', text) for text in texts]
     return [hashlib.md5(text.strip().encode("utf-8")).hexdigest() for text in stripped_texts]
+
+# this doesn't, it just strips the whitespace
+def get_hash(texts: List[str]) -> List[str]:
+    """Get hash of content field."""
+    return [hashlib.md5(text.strip().encode("utf-8")).hexdigest() for text in texts]
 
 
 def split_text_in_lines(text: str) -> List[str]:

--- a/download_scripts/download_datasets_multiprocessing.py
+++ b/download_scripts/download_datasets_multiprocessing.py
@@ -7,7 +7,7 @@ from datasets import load_dataset
 
 def download_dataset_multiprocessing(name_dataset):
     try:
-        dataset = load_dataset(name_dataset, use_auth_token="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", ignore_verifications=True)
+        dataset = load_dataset(name_dataset, use_auth_token=True, ignore_verifications=True)
         print("Done for dataset:", name_dataset)
     except:
         print("Failed for dataset:", name_dataset)

--- a/download_scripts/proper_size_estimation.py
+++ b/download_scripts/proper_size_estimation.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 def get_size(name_dataset):
     try:
-        dataset = load_dataset(name_dataset, use_auth_token="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", ignore_verifications=True, split="train")
+        dataset = load_dataset(name_dataset, use_auth_token=True, ignore_verifications=True, split="train")
         dataset = dataset.map(None, remove_columns=[column for column in dataset.column_names if column != "text"])
         print("Done for dataset:", name_dataset)
         return (name_dataset, sum([sys.getsizeof(item["text"]) for item in tqdm(dataset)]))

--- a/download_scripts/reload_newline_datasets.py
+++ b/download_scripts/reload_newline_datasets.py
@@ -8,11 +8,11 @@ from tqdm import tqdm
 
 def download_dataset_multiprocessing(name_dataset):
     try:
-        dataset = load_dataset(name_dataset, use_auth_token="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",
+        dataset = load_dataset(name_dataset, use_auth_token=True,
                                ignore_verifications=True)
         samples = "".join(dataset["train"].select(range(10))["text"])
         if samples.count("/n") > samples.count("\n"):
-            dataset = load_dataset(name_dataset, use_auth_token="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",
+            dataset = load_dataset(name_dataset, use_auth_token=True,
                                    ignore_verifications=True, download_mode="force_redownload")
             print(f"Reloaded for dataset {name_dataset}")
             samples = "".join(dataset["train"].select(range(10))["text"])


### PR DESCRIPTION
This makes document deduplication insensitive to whitespaces, numbers and punctuation.