### PR TITLE
change way to compute the size of the text

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import logging
 import random
-import sys
 from functools import partial
 from datasets import Dataset, load_dataset, load_from_disk, concatenate_datasets, set_caching_enabled
 from pathlib import Path
@@ -69,7 +68,11 @@ def quick_size_estimation(ds, content_key="text"):
     indices = rng.choice(len(ds), size=subset_size, replace=False, shuffle=False)
     partial_ds = ds.select(indices)
     ratio = float(len(ds)) / float(subset_size)
-    return sys.getsizeof("".join(partial_ds[content_key])) * ratio
+
+    len_bytes = 0
+    for content in partial_ds[content_key]:
+        len_bytes += len(content.encode())
+    return len_bytes * ratio
 
 def revert_bool_output(examples, filter_function):
     booleans = filter_function(examples)

--- a/clean.py
+++ b/clean.py
@@ -64,10 +64,7 @@ assert (MAPS_KEYS | FILTERS_KEYS).isdisjoint(DEDUPS_KEYS)
 
 def get_size_per_example(texts):
     size_values = [len(text.encode()) for text in texts]
-    examples = {
-        "text": texts,
-        "bytes_len": size_values
-    }
+    examples = {"bytes_len": size_values}
     return examples
 
 def quick_size_estimation(ds, 

--- a/clean.py
+++ b/clean.py
@@ -62,9 +62,12 @@ DEDUPS_KEYS = set(DEDUPS.keys())
 assert MAPS_KEYS.isdisjoint(FILTERS_KEYS)
 assert (MAPS_KEYS | FILTERS_KEYS).isdisjoint(DEDUPS_KEYS)
 
-def get_size_per_example(examples, content_key):
-    size_values = [len(text.encode()) for text in examples[content_key]]
-    examples["bytes_len"] = size_values
+def get_size_per_example(texts, content_key):
+    size_values = [len(text.encode()) for text in texts]
+    examples = {
+        "text": texts,
+        "bytes_len": size_values
+    }
     return examples
 
 def quick_size_estimation(ds, 
@@ -81,7 +84,9 @@ def quick_size_estimation(ds,
         partial(get_size_per_example, content_key=content_key),
         batched=True, 
         num_proc=num_proc,
-        batch_size=batch_size
+        batch_size=batch_size,
+        input_columns=[content_key],
+        remove_columns=partial_ds.column_names,
     )
     len_bytes = sum(partial_ds["bytes_len"][:])
     return len_bytes * ratio

--- a/clean.py
+++ b/clean.py
@@ -78,7 +78,7 @@ def quick_size_estimation(ds,
     ratio = float(len(ds)) / float(subset_size)
 
     partial_ds = partial_ds.map(
-        partial(get_size_per_example, content_key=content_key),
+        get_size_per_example,
         batched=True, 
         num_proc=num_proc,
         batch_size=batch_size,

--- a/clean.py
+++ b/clean.py
@@ -85,7 +85,7 @@ def quick_size_estimation(ds,
         input_columns=[content_key],
         remove_columns=partial_ds.column_names,
     )
-    len_bytes = sum(partial_ds["bytes_len"][:])
+    len_bytes = sum(partial_ds["bytes_len"])
     return len_bytes * ratio
 
 def revert_bool_output(examples, filter_function):

--- a/clean.py
+++ b/clean.py
@@ -62,7 +62,7 @@ DEDUPS_KEYS = set(DEDUPS.keys())
 assert MAPS_KEYS.isdisjoint(FILTERS_KEYS)
 assert (MAPS_KEYS | FILTERS_KEYS).isdisjoint(DEDUPS_KEYS)
 
-def get_size_per_example(texts, content_key):
+def get_size_per_example(texts):
     size_values = [len(text.encode()) for text in texts]
     examples = {
         "text": texts,

--- a/clean_helpers/filter_small_docs_in_datasets.py
+++ b/clean_helpers/filter_small_docs_in_datasets.py
@@ -1,6 +1,3 @@
-import sys
-
-
 def build_small_docs_filter(min_word):
     def filter_small_docs(examples):
         """Discard documents with less than min_word words"""
@@ -11,5 +8,5 @@ def build_small_docs_bytes_filter(min_bytes):
     # a byte of text usually turns into 0.3 tokens. a 256-token sequence would be ~850 bytes of text. I think anywhere from 500 to 1000 min bytes is reasonable.
     def filter_small_docs(examples):
         """Discard documents with less than min_word words"""
-        return [sys.getsizeof(text) >= min_bytes for text in examples["text"]]
+        return [len(text.encode()) >= min_bytes for text in examples["text"]]
     return filter_small_docs

--- a/download_scripts/proper_size_estimation.py
+++ b/download_scripts/proper_size_estimation.py
@@ -5,7 +5,7 @@ import multiprocessing
 from datasets import load_dataset
 from tqdm import tqdm
 
-def get_size_per_example(texts, content_key):
+def get_size_per_example(texts):
     size_values = [len(text.encode()) for text in texts]
     examples = {
         "text": texts,
@@ -18,7 +18,7 @@ def get_size(name_dataset, args):
         dataset = load_dataset(name_dataset, use_auth_token=True, ignore_verifications=True, split="train")
 
         dataset = dataset.map(
-            partial(get_size_per_example, content_key="text"),
+            partial(get_size_per_example),
             batched=True, 
             num_proc=num_proc,
             batch_size=batch_size,

--- a/download_scripts/proper_size_estimation.py
+++ b/download_scripts/proper_size_estimation.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import multiprocessing
-import sys
 
 from datasets import load_dataset
 from tqdm import tqdm
@@ -12,8 +11,11 @@ def get_size(name_dataset):
         dataset = load_dataset(name_dataset, use_auth_token=True, ignore_verifications=True, split="train")
         dataset = dataset.map(None, remove_columns=[column for column in dataset.column_names if column != "text"])
         print("Done for dataset:", name_dataset)
-        return (name_dataset, sys.getsizeof("".join(dataset["text"])))
-        # return (name_dataset, sum([sys.getsizeof(item["text"]) for item in tqdm(dataset)]))
+
+        len_bytes = 0
+        for content in dataset["text"]:
+            len_bytes += len(content.encode())
+        return (name_dataset, len_bytes)
     except Exception as e:
         print(f"Failed for dataset: {name_dataset} because of {e}")
         return (name_dataset, 0)

--- a/download_scripts/proper_size_estimation.py
+++ b/download_scripts/proper_size_estimation.py
@@ -7,10 +7,7 @@ from tqdm import tqdm
 
 def get_size_per_example(texts):
     size_values = [len(text.encode()) for text in texts]
-    examples = {
-        "text": texts,
-        "bytes_len": size_values
-    }
+    examples = {"bytes_len": size_values}
     return examples
 
 def get_size(name_dataset, args):

--- a/download_scripts/proper_size_estimation.py
+++ b/download_scripts/proper_size_estimation.py
@@ -5,9 +5,12 @@ import multiprocessing
 from datasets import load_dataset
 from tqdm import tqdm
 
-def get_size_per_example(examples, content_key):
-    size_values = [len(text.encode()) for text in examples[content_key]]
-    examples["bytes_len"] = size_values
+def get_size_per_example(texts, content_key):
+    size_values = [len(text.encode()) for text in texts]
+    examples = {
+        "text": texts,
+        "bytes_len": size_values
+    }
     return examples
 
 def get_size(name_dataset, args):
@@ -19,7 +22,8 @@ def get_size(name_dataset, args):
             batched=True, 
             num_proc=num_proc,
             batch_size=batch_size,
-            remove_columns=[column for column in dataset.column_names if column != "text"]
+            input_columns=["text"],
+            remove_columns=dataset.column_names
         )
         len_bytes = sum(dataset["bytes_len"][:])
         print("Done for dataset:", name_dataset)


### PR DESCRIPTION
As discussed on slack, the method `getsizeof()` doesn't measure the same thing as `len(text.encode())`. This PR proposes to change the way we compute the size of the text.

Note however: I think that this change will not be seen by the caches through the map and filter methods. The easiest solution would be to put `load_from_cache_file=False` in the arguments of these methods but we may want to use them for other filters / cleanings we have already executed.

# Test

I tested to run :

```
python clean.py \
    --dataset-path bigscience-catalogue-lm-data/lm_en_wikinews_filtered \
    --maps-and-filters filter_small_docs_bytes_500 \
    --save-path /home/lucile/data/result_filtering_cleaning/lm_en_wikinews_filtered.jsonl \
    --checks-save-path /home/lucile/data/result_filtering_cleaning/lm_en_wikinews_filtered_checks \
    --num-proc 4 \
    --sampling-size-map-check 100000 \
    --sampling-size-filter-check 100000 \
    --batch-size 100
```

## The output before 

```
03/07/2022 11:56:18 - INFO - __main__ - Applied filter: filter_small_docs_bytes_500
03/07/2022 11:56:18 - INFO - __main__ -      Initial number of samples: 54387 samples
03/07/2022 11:56:18 - INFO - __main__ -      Removed samples: 22412 samples
03/07/2022 11:56:18 - INFO - __main__ -      Removed percentage: 41.21 %
03/07/2022 11:56:18 - INFO - __main__ -      Final number of samples: 31975 samples
03/07/2022 11:56:18 - INFO - __main__ -      Initial size in bytes: 0.3100 GB
03/07/2022 11:56:18 - INFO - __main__ -      Removed bytes: 0.0232 GB
03/07/2022 11:56:18 - INFO - __main__ -      Removed percentage in bytes: 7.48 %
03/07/2022 11:56:18 - INFO - __main__ -      Final size in bytes: 0.2868 GB
```
## The output after

```
03/07/2022 11:57:59 - INFO - __main__ - Applied filter: filter_small_docs_bytes_500
03/07/2022 11:57:59 - INFO - __main__ -      Initial number of samples: 54387 samples
03/07/2022 11:57:59 - INFO - __main__ -      Removed samples: 23856 samples
03/07/2022 11:57:59 - INFO - __main__ -      Removed percentage: 43.86 %
03/07/2022 11:57:59 - INFO - __main__ -      Final number of samples: 30531 samples
03/07/2022 11:57:59 - INFO - __main__ -      Initial size in bytes: 0.0778 GB
03/07/2022 11:57:59 - INFO - __main__ -      Removed bytes: 0.0079 GB
03/07/2022 11:57:59 - INFO - __main__ -      Removed percentage in bytes: 10.18 %
03/07/2022 11:57:59 - INFO - __main__ -      Final size in bytes: 0.0699 GB
``` 