### PR TITLE
add sentence splitter functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,26 @@ where you should replace:
 - `path_to_file_with_dataset_ratios`: path to JSON file containing a dict with dataset names (keys) and their ratio
   (values) between 0 and 1.
 - `<dir_path_to_save_aggregated_dataset>`: directory path to save the aggregated dataset
+
+
+## Downloads for cleaning
+
+### Stanza
+
+```python
+import stanza
+
+for lang in {"ar", "ca", "eu", "id", "vi", "zh-hans", "zh-hant"}:
+    stanza.download(lang, logging_level="WARNING")
+```
+
+### Indic NLP library
+
+```bash
+git clone https://github.com/anoopkunchukuttan/indic_nlp_resources.git
+export INDIC_RESOURCES_PATH=<PATH_TO_REPO>
+```
+
+### NLTK
+import nltk
+nltk.download("punkt")

--- a/clean.py
+++ b/clean.py
@@ -12,7 +12,7 @@ from numpy.random import default_rng
 from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, filter_wiki_user_titles, \
     replace_newline_with_space, build_dedup_template, dedup_document, build_line_with_substring_remover, \
     en_wiktionary_stripper, build_small_docs_bytes_filter, dedup_document_on_url, filter_remove_empty_docs,\
-    build_reference_remover, build_sentence_splitter, remove_newlines, sentence_split_langs
+    build_reference_remover, build_sentence_splitter, sentence_split_langs
 from clean_helpers.stopwords import stopwords
 
 set_verbosity_info()
@@ -28,7 +28,6 @@ MAPS = {
     "remove_html_spans_sanad": build_line_with_substring_remover(["<img", "]]>", "<![CDATA", "//DW", "var ", "xtImg", "To view this video please enable JavaScript"]),
     "remove_wiki_mojibake": build_line_with_substring_remover(["À À"]),
     "strip_substrings_en_wiktionary": en_wiktionary_stripper,
-    "remove_newlines": remove_newlines,
     ** {
     f"remove_references_{lang}": build_reference_remover(lang) for lang in set(stopwords.keys())
     },

--- a/clean.py
+++ b/clean.py
@@ -3,6 +3,8 @@ import json
 import logging
 import random
 from functools import partial
+
+import torch
 from datasets import Dataset, load_dataset, load_from_disk, concatenate_datasets, set_caching_enabled
 from pathlib import Path
 from typing import Tuple, Optional, Callable
@@ -19,6 +21,7 @@ set_verbosity_info()
 logger = logging.getLogger(__name__)
 # TODO: Uncomment when you have caching issue
 # set_caching_enabled(False)
+torch.set_num_threads(1)
 
 # Map functions: function(batch: Dict) -> Dict
 MAPS = {
@@ -202,8 +205,7 @@ def apply_function(function_name: str, ds: Dataset, args) -> Tuple[Dataset, Opti
                 map_function,
                 batched=True,
                 num_proc=args.num_proc,
-                batch_size=args.batch_size,
-                load_from_cache_file=False
+                batch_size=args.batch_size
             )
         log_stats(f"Applied map function: {function_name}", ds, mapped_ds, operation_type="Modified", args=args)
         if args.checks_save_path is not None:

--- a/clean.py
+++ b/clean.py
@@ -12,7 +12,7 @@ from numpy.random import default_rng
 from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, filter_wiki_user_titles, \
     replace_newline_with_space, build_dedup_template, dedup_document, build_line_with_substring_remover, \
     en_wiktionary_stripper, build_small_docs_bytes_filter, dedup_document_on_url, filter_remove_empty_docs,\
-    build_reference_remover
+    build_reference_remover, build_sentence_splitter, remove_newlines, sentence_split_langs
 from clean_helpers.stopwords import stopwords
 
 set_verbosity_info()
@@ -28,9 +28,11 @@ MAPS = {
     "remove_html_spans_sanad": build_line_with_substring_remover(["<img", "]]>", "<![CDATA", "//DW", "var ", "xtImg", "To view this video please enable JavaScript"]),
     "remove_wiki_mojibake": build_line_with_substring_remover(["À À"]),
     "strip_substrings_en_wiktionary": en_wiktionary_stripper,
+    "remove_newlines": remove_newlines,
     ** {
     f"remove_references_{lang}": build_reference_remover(lang) for lang in set(stopwords.keys())
-    }
+    },
+    ** {f"split_sentences_{lang}": build_sentence_splitter(lang) for lang in sentence_split_langs}
 }
 # Filter functions: function(batch: Dict) -> Dict
 FILTERS = {

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -5,3 +5,4 @@ from .map_strip_substring import en_wiktionary_stripper
 from .map_remove_references import build_reference_remover
 from .clean_lines import build_line_with_substring_remover
 from .deduplication import build_dedup_template, dedup_document, dedup_document_on_url
+from .sentence_splitter import build_sentence_splitter, remove_newlines, sentence_split_langs

--- a/clean_helpers/__init__.py
+++ b/clean_helpers/__init__.py
@@ -5,4 +5,4 @@ from .map_strip_substring import en_wiktionary_stripper
 from .map_remove_references import build_reference_remover
 from .clean_lines import build_line_with_substring_remover
 from .deduplication import build_dedup_template, dedup_document, dedup_document_on_url
-from .sentence_splitter import build_sentence_splitter, remove_newlines, sentence_split_langs
+from .sentence_splitter import build_sentence_splitter, sentence_split_langs

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -39,15 +39,15 @@ def build_stanza_splitter(lang, batch_size=32):
 
 def build_indic_splitter(lang):
     lang_to_indic = {
-        "hindi-bn": "bn",
-        "hindi-gu": "gu",
-        "hindi-hi": "hi",
-        "hindi-kn": "kn",
-        "hindi-ml": "ml",
-        "hindi-mr": "mr",
-        "hindi-pa": "pa",
-        "hindi-ta": "ta",
-        "hindi-te": "te"
+        "indic-bn": "bn",
+        "indic-gu": "gu",
+        "indic-hi": "hi",
+        "indic-kn": "kn",
+        "indic-ml": "ml",
+        "indic-mr": "mr",
+        "indic-pa": "pa",
+        "indic-ta": "ta",
+        "indic-te": "te"
         }
     def splitter(examples):
         split_texts = ["\n".join(sentence_tokenize.sentence_split(text, lang=lang_to_indic[lang])) for text in examples["text"]]
@@ -58,7 +58,7 @@ def build_indic_splitter(lang):
 def build_sentence_splitter(lang):
     stanza_list = {"ar", "ca", "eu", "id", "vi", "zhs", "zht"}
     nltk_list = {"en", "fr", "pt", "es"}
-    indic_list = {"hindi-bn", "hindi-gu", "hindi-hi", "hindi-kn", "hindi-ml", "hindi-mr", "hindi-pa", "hindi-ta", "hindi-te"}
+    indic_list = {"indic-bn", "indic-gu", "indic-hi", "indic-kn", "indic-ml", "indic-mr", "indic-pa", "indic-ta", "indic-te"}
     
     assert len(stanza_list & nltk_list) == 0
     assert len(stanza_list & indic_list) == 0
@@ -75,5 +75,5 @@ def build_sentence_splitter(lang):
 
 
 sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "en", "fr", 
-                        "pt", "es", "hindi-bn", "hindi-gu", "hindi-hi", "hindi-kn",
-                        "hindi-ml", "hindi-mr", "hindi-pa", "hindi-ta", "hindi-te"}
+                        "pt", "es", "indic-bn", "indic-gu", "indic-hi", "indic-kn",
+                        "indic-ml", "indic-mr", "indic-pa", "indic-ta", "indic-te"}

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -72,7 +72,7 @@ def build_sentence_splitter(lang):
     elif lang in indic_list:
         return build_indic_splitter(lang)
     else:
-        return lambda x: x
+        NotImplementedError(f"Lang '{lang}' is has no sentence splitter implemented.")
 
 
 sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "en", "fr", 

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -27,12 +27,11 @@ def build_stanza_splitter(lang, batch_size=32):
     lang_to_stanza = {"zht": "zh-hant", "zhs": "zh-hans"}
     lang = lang_to_stanza.get(lang, lang)
     tokenizer = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
-    nlp = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
                           use_gpu=torch.cuda.is_available())
     
     def splitter(examples):
         split_texts = []
-        for document in batch(examples["text"], nlp, batch_size=batch_size):
+        for document in batch(examples["text"], tokenizer, batch_size=batch_size):
             split_texts.append("\n".join([sentence.text for sentence in document.sentences]))
         return {**examples, "text": split_texts }        
     return splitter

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -71,7 +71,7 @@ def build_sentence_splitter(lang):
     elif lang in indic_list:
         return build_indic_splitter(lang)
     else:
-        NotImplementedError(f"Lang '{lang}' is has no sentence splitter implemented.")
+        NotImplementedError(f"Lang '{lang}' has no sentence splitter implemented.")
 
 
 sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "en", "fr", 

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -24,8 +24,8 @@ def build_nltk_splitter(lang):
 
 
 def build_stanza_splitter(lang, batch_size=32):
-    if len(lang)==3:
-        lang.replace("zh", "zh-han") # zhs-> zh-hans, zht -> zh-hant
+    lang_to_stanza = {"zht": "zh-hant", "zhs": "zh-hans"}
+    lang = lang_to_stanza.get(lang, lang)
     tokenizer = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
     nlp = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
                           use_gpu=torch.cuda.is_available())
@@ -57,10 +57,14 @@ def build_indic_splitter(lang):
 
 
 def build_sentence_splitter(lang):
-    stanza_list = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "zh"}
+    stanza_list = {"ar", "ca", "eu", "id", "vi", "zhs", "zht"}
     nltk_list = {"en", "fr", "pt", "es"}
-    indic_list = {"bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te"}
+    indic_list = {"hindi-bn", "hindi-gu", "hindi-hi", "hindi-kn", "hindi-ml", "hindi-mr", "hindi-pa", "hindi-ta", "hindi-te"}
     
+    assert len(stanza_list & nltk_list) == 0
+    assert len(stanza_list & indic_list) == 0
+    assert len(indic_list & nltk_list) == 0
+
     if lang in stanza_list:
         return build_stanza_splitter(lang)
     elif lang in nltk_list:
@@ -71,9 +75,6 @@ def build_sentence_splitter(lang):
         return lambda x: x
 
 
-def remove_newlines(examples):
-    return {**examples, "text": [text.replace("\n", " ") for text in examples["text"]]}  
-
-
-sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zh", "zhs", "zht", "en", "fr", 
-                        "pt", "es", "bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te"}
+sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "en", "fr", 
+                        "pt", "es", "hindi-bn", "hindi-gu", "hindi-hi", "hindi-kn",
+                        "hindi-ml", "hindi-mr", "hindi-pa", "hindi-ta", "hindi-te"}

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -1,0 +1,76 @@
+import subprocess
+import os
+import torch
+import stanza
+from stanza_batch import batch
+from indicnlp import common
+from indicnlp.tokenize import sentence_tokenize
+import nltk
+from nltk.tokenize import sent_tokenize
+
+
+def build_nltk_splitter(lang):
+    nltk.download("punkt")
+    lang_to_punkt = {
+        "en": "english",
+        "fr": "french",
+        "pt": "portuguese",
+        "es": "spanish"
+    }
+    
+    def splitter(examples):
+        split_texts = ["\n".join(sent_tokenize(text, language=lang_to_punkt[lang])) for text in examples["text"]]
+        return {**examples, "text": split_texts }        
+    return splitter
+
+
+def build_stanza_splitter(lang, batch_size=32):
+    if len(lang)==3:
+        lang.replace("zh", "zh-han") # zhs-> zh-hans, zht -> zh-hant
+    stanza.download(lang, logging_level="WARNING")
+    nlp = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
+                          use_gpu=torch.cuda.is_available())
+    
+    def splitter(examples):
+        split_texts = []
+        for document in batch(examples["text"], nlp, batch_size=batch_size):
+            split_texts.append("\n".join([sentence.text for sentence in document.sentences]))
+        return {**examples, "text": split_texts }        
+    return splitter
+
+
+def build_indic_splitter(lang):
+    INDIC_NLP_RESOURCES="./indic_nlp_resources"
+    INDIC_NLP_RESOURCES_REPO = "https://github.com/anoopkunchukuttan/indic_nlp_resources.git"
+
+    if not os.path.exists(INDIC_NLP_RESOURCES):
+        subprocess.run(["git", "clone", INDIC_NLP_RESOURCES_REPO])
+    common.set_resources_path(INDIC_NLP_RESOURCES)
+
+    def splitter(examples):
+        split_texts = ["\n".join(sentence_tokenize.sentence_split(text, lang=lang)) for text in examples["text"]]
+        return {**examples, "text": split_texts }        
+    return splitter
+
+
+def build_sentence_splitter(lang):
+    stanza_list = {"ar", "ca", "eu", "id", "vi", "zhs", "zht", "zh"}
+    nltk_list = {"en", "fr", "pt", "es"}
+    indic_list = {"bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te"}
+    
+    if lang in stanza_list:
+        return build_stanza_splitter(lang)
+    elif lang in nltk_list:
+        return build_nltk_splitter(lang)
+    elif lang in indic_list:
+        return build_indic_splitter(lang)
+    else:
+        return lambda x: x
+
+
+def remove_newlines(examples):
+    return {**examples, "text": [text.replace("\n", " ") for text in examples["text"]]}  
+
+
+sentence_split_langs = {"ar", "ca", "eu", "id", "vi", "zh", "zhs", "zht", "en", "fr", 
+                        "pt", "es", "bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te"}

--- a/clean_helpers/sentence_splitter.py
+++ b/clean_helpers/sentence_splitter.py
@@ -10,7 +10,6 @@ from nltk.tokenize import sent_tokenize
 
 
 def build_nltk_splitter(lang):
-    nltk.download("punkt")
     lang_to_punkt = {
         "en": "english",
         "fr": "french",
@@ -27,7 +26,7 @@ def build_nltk_splitter(lang):
 def build_stanza_splitter(lang, batch_size=32):
     if len(lang)==3:
         lang.replace("zh", "zh-han") # zhs-> zh-hans, zht -> zh-hant
-    stanza.download(lang, logging_level="WARNING")
+    tokenizer = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
     nlp = stanza.Pipeline(lang, logging_level="WARNING", processors='tokenize',
                           use_gpu=torch.cuda.is_available())
     
@@ -40,16 +39,20 @@ def build_stanza_splitter(lang, batch_size=32):
 
 
 def build_indic_splitter(lang):
-    INDIC_NLP_RESOURCES="./indic_nlp_resources"
-    INDIC_NLP_RESOURCES_REPO = "https://github.com/anoopkunchukuttan/indic_nlp_resources.git"
-
-    if not os.path.exists(INDIC_NLP_RESOURCES):
-        subprocess.run(["git", "clone", INDIC_NLP_RESOURCES_REPO])
-    common.set_resources_path(INDIC_NLP_RESOURCES)
-
+    lang_to_indic = {
+        "hindi-bn": "bn",
+        "hindi-gu": "gu",
+        "hindi-hi": "hi",
+        "hindi-kn": "kn",
+        "hindi-ml": "ml",
+        "hindi-mr": "mr",
+        "hindi-pa": "pa",
+        "hindi-ta": "ta",
+        "hindi-te": "te"
+        }
     def splitter(examples):
-        split_texts = ["\n".join(sentence_tokenize.sentence_split(text, lang=lang)) for text in examples["text"]]
-        return {**examples, "text": split_texts }        
+        split_texts = ["\n".join(sentence_tokenize.sentence_split(text, lang=lang_to_indic[lang])) for text in examples["text"]]
+        return {**examples, "text": split_texts }
     return splitter
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ python-dotenv
 py7zr
 rarfile
 zstandard
+stanza==1.2.0
+stanza-batch
+nltk
+indic-nlp-library


### PR DESCRIPTION
Adds sentence splitter functions as well as function to remove newlines. I think we should remove the newlines after adding them as the process can be imperfect and a whitespace at the wrong place is more natural than a newline. 

for the wiki-rest datasets the steps should be:
1. add newlines with sentence splitter
2. line deduplication
3. remove newlines

@thomasw21 should we add this to your scripts that creates the filters for each dataset programmatically? The rule would be: add the three steps above to all datasets where the dataset name contains wiki but not wikipedia.