### PR TITLE
Replace filter with map

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -103,7 +103,7 @@ def revert_bool_output(examples, filter_function):
 def convert_filter_to_map(batch: Dict, filter_function: Callable[[Dict], List[bool]]) -> Dict:
     samples_to_keep = filter_function(batch)
     return {
-        key: [elt for to_keep, elt in zip(samples_to_keep, value)]
+        key: [elt for to_keep, elt in zip(samples_to_keep, value) if to_keep]
         for key, value in batch.items()
     }
 

--- a/clean.py
+++ b/clean.py
@@ -100,6 +100,13 @@ def revert_bool_output(examples, filter_function):
     booleans = filter_function(examples)
     return [not boolean for boolean in booleans]
 
+def convert_filter_to_map(batch: Dict, filter_function: Callable[[Dict], List[bool]]) -> Dict:
+    samples_to_keep = filter_function(batch)
+    return {
+        key: [elt for to_keep, elt in zip(samples_to_keep, value)]
+        for key, value in batch
+    }
+
 def filter_diff_text(examples, in_text_col, out_text_col):
     return [text_in != text_out for text_in, text_out in zip(examples[in_text_col], examples[out_text_col])]
 
@@ -220,7 +227,7 @@ def apply_function(function_name: str, ds: Dataset, args) -> Tuple[Dataset, Opti
             return mapped_ds, None
     elif function_name in FILTERS:
         filter_function = FILTERS[function_name]
-        filtered_ds = ds.filter(filter_function, batched=True, num_proc=args.num_proc, batch_size=args.batch_size)
+        filtered_ds = ds.map(partial(convert_filter_to_map, filter_function=filter_function), batched=True, num_proc=args.num_proc, batch_size=args.batch_size)
         log_stats(f"Applied filter: {function_name}", ds, filtered_ds, operation_type="Removed", args=args)
         if args.checks_save_path is not None:
             return filtered_ds, get_filtered_out_documents(ds, filter_function, args.num_proc, args.batch_size, args.sampling_size_filter_checks)

--- a/clean.py
+++ b/clean.py
@@ -104,7 +104,7 @@ def convert_filter_to_map(batch: Dict, filter_function: Callable[[Dict], List[bo
     samples_to_keep = filter_function(batch)
     return {
         key: [elt for to_keep, elt in zip(samples_to_keep, value)]
-        for key, value in batch
+        for key, value in batch.items()
     }
 
 def filter_diff_text(examples, in_text_col, out_text_col):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ python-dotenv
 py7zr
 rarfile
 zstandard
-stanza==1.2.0
 stanza-batch
+stanza==1.2.3 # This breaks stanza-batch dependency
 nltk
 indic-nlp-library
 underthesea


### PR DESCRIPTION
We don't have memory constraint and having consecutive .filter is just too slow. Instead I suggest converting all filters to maps (except the ones that are essentially followed by only "select" / "filters").

This will regenerate eveything, but the operations should match perfectly.

cc @lhoestq this is what I had in mind.