### PR TITLE
new way to simplify dedup url

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -16,7 +16,7 @@ from clean_helpers import build_small_docs_filter, filter_wiki_non_text_type, fi
     en_wiktionary_stripper, build_small_docs_bytes_filter, build_dedup_document, filter_remove_empty_docs,\
     build_reference_remover, build_sentence_splitter, sentence_split_langs
 from clean_helpers.deduplication import document_batch_normalizer, url_host_and_path_batch_normalizer, \
-    url_lm_es_pseudocrawl_filtered_341_es_cointelegraph_com
+    url_lm_es_pseudocrawl_filtered_341_es_cointelegraph_com, url_lm_en_pseudocrawl_filtered_619_www_qut_edu_au
 from clean_helpers.stopwords import stopwords
 
 set_verbosity_info()
@@ -62,6 +62,9 @@ DEDUPS = {
     "dedup_document_on_url": build_dedup_document(url_host_and_path_batch_normalizer),
     "dedup_document_on_url_lm_es_pseudocrawl-filtered_341_es_cointelegraph_com": build_dedup_document(
         url_lm_es_pseudocrawl_filtered_341_es_cointelegraph_com
+    ),
+    "dedup_document_on_url_lm_en_pseudocrawl_filtered_619_www_qut_edu_au": build_dedup_document(
+        url_lm_en_pseudocrawl_filtered_619_www_qut_edu_au
     )
 }
 

--- a/clean_helpers/deduplication.py
+++ b/clean_helpers/deduplication.py
@@ -62,7 +62,6 @@ def build_dedup_document(batch_normalizer: Callable[[Dict], List[str]]):
             num_proc=num_proc,
             batched=True,
             batch_size=batch_size,
-            load_from_cache_file=False
         )
 
         hashes = set()


### PR DESCRIPTION
This PR proposes to modify the way the url is simplified before creating the hash on it for deduplication.

The first modification is to keep the id in the querys parameters. 

More testing should be done to see if other query parameters in the urls may not be important to distinguish 2 examples. For example in the `lm_en_pseudocrawl-filtered_619_www_qut_edu_au` dataset, I see urls of type `https://www.qut.edu.au/study/unit?unitCode=ERB316`. I don't know if this is an overlapping exemple with `https://www.qut.edu.au/study/unit?unitCode=LLB346` (as is this dedup it assumes that there is an overlap).